### PR TITLE
Append current date and time to filename on export

### DIFF
--- a/GUI/GUI.gd
+++ b/GUI/GUI.gd
@@ -53,7 +53,8 @@ func save_image(img):
 		var filesaver = get_tree().root.get_node("/root/HTML5File")
 		filesaver.save_image(img, "Space Background")
 	else:
-		img.save_png("res://Space Background.png")
+		var ts = Time.get_datetime_dict_from_system()
+		img.save_png("res://Space Background %04d%02d%02d%02d%02d%02d.png" % [ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second])
 
 func _on_SaveTimer_timeout():
 	export_image()


### PR DESCRIPTION
## What?
Add the current date and time (the format being `YYYYMMDDHHMMSS` ) to the export file name.  e.g. `Space Background 20230509094600.png`.

## Why?
This is to avoid overwriting a previously exported image of the same name.

## How?
In `GUI.gd` in the `save_image(img)` function, the current date and time is determined through a call to `Time.get_datetime_dict_from_system()`. This is then used in a format string and appended to the filename.

## Testing?
This was tested manually.

## Screenshots (optional)
n/a

## Anything Else?
n/a
